### PR TITLE
fix: get camera without connect

### DIFF
--- a/zivid_nova/routes/cameras.py
+++ b/zivid_nova/routes/cameras.py
@@ -160,7 +160,7 @@ async def get_camera_frame2d_color(serial_number: str) -> Response:
 async def get_camera_firmware_up_to_date(serial_number: str) -> bool:
     """Check if the camera firmware is up to date"""
 
-    camera = zivid_app.get_connected_camera(serial_number)
+    camera = zivid_app.get_camera(serial_number)
     if camera.state.connected:
         camera.disconnect()
 
@@ -171,7 +171,7 @@ async def get_camera_firmware_up_to_date(serial_number: str) -> bool:
 async def update_camera_firmware(serial_number: str):
     """Update the camera firmware if necessary. Also performs downgrades."""
 
-    camera = zivid_app.get_connected_camera(serial_number)
+    camera = zivid_app.get_camera(serial_number)
     if camera.state.connected:
         camera.disconnect()
 

--- a/zivid_nova/zivid_app.py
+++ b/zivid_nova/zivid_app.py
@@ -38,8 +38,8 @@ def get_cameras() -> list[zivid.Camera]:
     return list(camera_cache.values())
 
 
-def get_connected_camera(serial_number: str) -> zivid.Camera:
-    """Get a camera by serial number. Makes sure the camera is connected."""
+def get_camera(serial_number: str) -> zivid.Camera:
+    """Get a camera by serial number. Does not check if the camera is connected."""
 
     # Check if camera is in cache. If not, update cache and try again
     if not serial_number in camera_cache:
@@ -47,7 +47,13 @@ def get_connected_camera(serial_number: str) -> zivid.Camera:
         if not serial_number in camera_cache:
             raise ValueError(f"Camera with serial number {serial_number} not found")
 
-    camera = camera_cache[serial_number]
+    return camera_cache[serial_number]
+
+
+def get_connected_camera(serial_number: str) -> zivid.Camera:
+    """Get a camera by serial number. Makes sure the camera is connected."""
+
+    camera = get_camera(serial_number)
 
     # Cameras can be disconnected during operation. Reconnect if needed.
     # If it fails remove it from the cache and raise an error


### PR DESCRIPTION
Connect failed for cameras with mismatching firmware versions so the firmware endpoints failed to and an update was not possible. Added another getter that doesnt connect automatically.