### PR TITLE
update poetry version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1-mesa-glx=* \
     libglib2.0-0=* && \
     wget --progress=dot:giga \
-        https://downloads.zivid.com/sdk/releases/2.14.1+b4e8f261-1/u22/amd64/zivid_2.14.1+b4e8f261-1_amd64.deb \
-        https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.12149.1/intel-igc-core_1.0.12149.1_amd64.deb \
-        https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.12149.1/intel-igc-opencl_1.0.12149.1_amd64.deb \
-        https://github.com/intel/compute-runtime/releases/download/22.39.24347/intel-level-zero-gpu-dbgsym_1.3.24347_amd64.ddeb \
-        https://github.com/intel/compute-runtime/releases/download/22.39.24347/intel-level-zero-gpu_1.3.24347_amd64.deb \
-        https://github.com/intel/compute-runtime/releases/download/22.39.24347/intel-opencl-icd-dbgsym_22.39.24347_amd64.ddeb \
-        https://github.com/intel/compute-runtime/releases/download/22.39.24347/intel-opencl-icd_22.39.24347_amd64.deb \
-        https://github.com/intel/compute-runtime/releases/download/22.39.24347/libigdgmm12_22.2.0_amd64.deb &&  \
+    https://downloads.zivid.com/sdk/releases/2.14.1+b4e8f261-1/u22/amd64/zivid_2.14.1+b4e8f261-1_amd64.deb \
+    https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.12149.1/intel-igc-core_1.0.12149.1_amd64.deb \
+    https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.12149.1/intel-igc-opencl_1.0.12149.1_amd64.deb \
+    https://github.com/intel/compute-runtime/releases/download/22.39.24347/intel-level-zero-gpu-dbgsym_1.3.24347_amd64.ddeb \
+    https://github.com/intel/compute-runtime/releases/download/22.39.24347/intel-level-zero-gpu_1.3.24347_amd64.deb \
+    https://github.com/intel/compute-runtime/releases/download/22.39.24347/intel-opencl-icd-dbgsym_22.39.24347_amd64.ddeb \
+    https://github.com/intel/compute-runtime/releases/download/22.39.24347/intel-opencl-icd_22.39.24347_amd64.deb \
+    https://github.com/intel/compute-runtime/releases/download/22.39.24347/libigdgmm12_22.2.0_amd64.deb &&  \
     apt-get install -y --no-install-recommends ./*.deb && \
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip \
-    && pip install poetry==1.8.2
+    && pip install poetry==2.1.3
 
 ENV POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_IN_PROJECT=1 \
@@ -31,15 +31,12 @@ ENV VIRTUAL_ENV=/zivid-nova/.venv PATH="/zivid-nova/.venv/bin:$PATH"
 
 WORKDIR /zivid-nova
 
-# install dependencies
+# copy package
 COPY pyproject.toml poetry.lock ./
-RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --no-dev
-
-# zivid_nova package
 COPY static/ static/
 COPY zivid_nova/ ./zivid_nova/
 
-# need to install again, otherwise poetry complains with warning that the serve script is not installed
-RUN poetry install --no-dev
+# install dependencies
+RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --without dev
 
 ENTRYPOINT ["poetry", "run", "serve"]


### PR DESCRIPTION
Issue:
`Starting from version 20.31.0, virtualenv has removed the --wheel argument. However, Poetry versions 1.7.x and 1.8.x still attempt to invoke virtualenv with this now-unsupported flag, leading to the error you're seeing.`

This lead to a missing zivid module after installation. Updating poetry should fix this incompatibility.